### PR TITLE
Add config for Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+build/*
+
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Makefile
+cmake_install.cmake
+install_manifest.txt
+CTestTestfile.cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ os:
 language:
   - cpp
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-
 script:
   - mkdir build
   - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: false
+
+os:
+  - linux
+
+language:
+  - cpp
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+
+script:
+  - mkdir build
+  - cd build
+  - cmake ..
+  - make
+
+notifications:
+  email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,3 @@ file(GLOB SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/sample_src/*.cpp
                     ${CMAKE_CURRENT_SOURCE_DIR}/src/*.hpp)
 
 add_executable(${PROJECT_NAME_STR} ${SRC_FILES})
-
-if (CMAKE_COMPILER_IS_GNUCXX)
-  add_definitions(-fopenmp)
-  target_link_libraries(${PROJECT_NAME_STR} gomp)
-elseif (MSVC)
-  add_definitions(/EHsc /openmp)
-endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 
 set(PROJECT_NAME_STR builder_sample)
+set(CMAKE_CXX_STANDARD 11)
 
 project (${PROJECT_NAME_STR})
 


### PR DESCRIPTION
Since Linux build is usually broken, let's add a pre-commit builder. Travis can build this project in a minute and it's free for all public github projects. This PR adds only config. Travis should be enabled by the owner of this repo.